### PR TITLE
Disable experimental backend search and refresher

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -92,11 +92,14 @@ Sandstorm:
       # Integration of KISSearch in the Neos Backend search bar.
       backendSearch:
         # Enable/Disable the feature. If disabled, the original search endpoint is used
-        enabled: true
+        # THIS FEATURE IS STILL EXPERIMENTAL.
+        enabled: false
         # Which KISSearch endpoint to use for the backend search.
         # Expects a filter with ID "neos"
         endpoint: neos-backend
 
       # Auto refresh dependencies on node publish events
       refresher:
-        autoRefreshEnabled: true
+        # THIS FEATURE IS STILL EXPERIMENTAL, AND IS CURRENTLY
+        # NOT WORKING CORRECTLY (indexes happen on every save, instead of every publish; and the delays for even smallish websites is quite high (5-10s))
+        autoRefreshEnabled: false


### PR DESCRIPTION
- Auto Refresh is currently not working correctly, as it is triggered on every CHANGE and not just during publish (also for user workspaces)

- unsure about BackendSearch; because this is a lot faster with Neos 9 now than with Neos 8.x; so I am unsure if we should provide this feature by default here. Is it actually meaningfully faster than the built in version? If no, I'd like to keep the built-in version by default for maximum core compatibility.