### PR TITLE
FIX: umlauts error in search and orphaned workspaces and broken command

### DIFF
--- a/src/Sandstorm.KISSearch.Api/Classes/DBAbstraction/MySQLHelper.php
+++ b/src/Sandstorm.KISSearch.Api/Classes/DBAbstraction/MySQLHelper.php
@@ -113,18 +113,28 @@ class MySQLHelper
     {
         return self::normalizeFulltext(
             <<<SQL
-                json_extract($valueSql, '$.$jsonKey.value')
+                json_unquote(json_extract($valueSql, '$.$jsonKey.value'))
             SQL
         );
     }
 
     public static function normalizeFulltext(string $valueSql): string
     {
-        return <<<SQL
-            replace(replace(replace(replace(
-                lower($valueSql),
-                'ä','ae'),'ö','oe'), 'ü','ue'), 'ß','ss')
-        SQL;
+        // Convert to binary first to do collation-agnostic byte-level replacement,
+        // then convert back to utf8mb4. This avoids "Illegal mix of collations" errors.
+        // Ä/Ö/Ü are lowercased first by lower() before the byte replacement.
+        // UTF-8 hex: ä=C3A4→ae(6165), ö=C3B6→oe(6F65), ü=C3BC→ue(7565), ß=C39F→ss(7373)
+        $umlauts = [
+            "x'C3A4'" => "x'6165'", // ä → ae
+            "x'C3B6'" => "x'6F65'", // ö → oe
+            "x'C3BC'" => "x'7565'", // ü → ue
+            "x'C39F'" => "x'7373'", // ß → ss
+        ];
+        $sql = "convert(lower($valueSql) using binary)";
+        foreach ($umlauts as $from => $to) {
+            $sql = "replace($sql, $from, $to)";
+        }
+        return "convert($sql using utf8mb4)";
     }
 
     public static function extractAllText(string $valueSql): string
@@ -176,7 +186,7 @@ class MySQLHelper
     {
         $sanitized = trim($userInput);
         $sanitized = mb_strtolower($sanitized);
-        $sanitized = str_replace(['ä', 'ö', 'ü', 'ß'], ['ae', 'oe', 'ue', 'ss'], $sanitized);
+        $sanitized = str_replace(['ä', 'ö', 'ü', 'ß', 'Ä', 'Ö', 'Ü'], ['ae', 'oe', 'ue', 'ss', 'ae', 'oe', 'ue'], $sanitized);
 
         $specialChars = str_split(self::SPECIAL_CHARACTERS);
         $sanitized = str_replace($specialChars, ' ', $sanitized);

--- a/src/Sandstorm.KISSearch.Flow/Classes/Command/KISSearchCommandController.php
+++ b/src/Sandstorm.KISSearch.Flow/Classes/Command/KISSearchCommandController.php
@@ -134,7 +134,7 @@ class KISSearchCommandController extends CommandController
     public function printSchemaCreateCommand(?string $database = null): void
     {
         $this->printScript($database, 'CREATE schema', function (DatabaseType $databaseType) {
-            SchemaTool::createSchemaSql(
+            return SchemaTool::createSchemaSql(
                 $databaseType,
                 $this->searchSchemas->getSchemaConfiguration(),
                 $this->instanceProvider

--- a/src/Sandstorm.KISSearch.Neos/Classes/Schema/NeosContentSearchSchema.php
+++ b/src/Sandstorm.KISSearch.Neos/Classes/Schema/NeosContentSearchSchema.php
@@ -650,6 +650,7 @@ class NeosContentSearchSchema implements SearchSchemaInterface, SearchDependency
                             on ws.currentContentStreamId = nd.contentstreamid
                     where nd.site_nodename is not null
                       and nd.is_not_hidden
+                      and ws.name is not null
                       and (sandstorm_kissearch_neos_is_document_$contentRepositoryId(nd.nodetype)
                         or sandstorm_kissearch_neos_is_content_$contentRepositoryId(nd.nodetype));
                 commit;


### PR DESCRIPTION
- in some cases the neos maria db contained umlauts already encoded like "W\u00e4rmeplan"
- not sure why that happend but the fix makes the normalization agnostic
- also fixes a problem with orphaned content streams by checking if workspace name is null
- also fixed missing return in the printSchemaCreateCommand closure, which caused the command to crash with a TypeError and made it impossible to verify the generated